### PR TITLE
Remove logger

### DIFF
--- a/assets/sdp-dnsmasq
+++ b/assets/sdp-dnsmasq
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 
 SETDNS_SOCKET=/var/run/appgate/dns-set.sock
-SDP_LOGS_PIPE=/sdp-logs-pipe
 
 mk_dnsmasq_conf () {
     KUBE_DNS_SERVICE=$(cat /etc/resolv.conf  | awk 'BEGIN{c=0}
@@ -23,10 +22,8 @@ EOF
 mk_dnsmasq_conf
 
 # Start dnsmasq now so it has not pid 1
-rm -f $SDP_LOGS_PIPE ; mkfifo $SDP_LOGS_PIPE
-/sdp-dnsmasq/sdp-logger $SDP_LOGS_PIPE &
 /usr/sbin/dnsmasq --pid-file=/sdp-dnsmasq/dnsmasq.pid --port=53 --local-service \
-		  --listen-address=127.0.0.1 --log-queries -8 $SDP_LOGS_PIPE
+          --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
 
 # Start listening for events from sdp-driver
 # socat will fork sdp-dnsmasq-set-dns and it will send data receive in the socket to the

--- a/assets/sdp-dnsmasq
+++ b/assets/sdp-dnsmasq
@@ -23,7 +23,7 @@ mk_dnsmasq_conf
 
 # Start dnsmasq now so it has not pid 1
 /usr/sbin/dnsmasq --pid-file=/sdp-dnsmasq/dnsmasq.pid --port=53 --local-service \
-          --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
+                  --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
 
 # Start listening for events from sdp-driver
 # socat will fork sdp-dnsmasq-set-dns and it will send data receive in the socket to the

--- a/assets/sdp-dnsmasq
+++ b/assets/sdp-dnsmasq
@@ -22,8 +22,9 @@ EOF
 mk_dnsmasq_conf
 
 # Start dnsmasq now so it has not pid 1
+# --log-facility sends the logs to the stdout the process with PID 1
 /usr/sbin/dnsmasq --pid-file=/sdp-dnsmasq/dnsmasq.pid --port=53 --local-service \
-                  --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
+                  --listen-address=127.0.0.1 --log-queries --log-facility /proc/1/fd/1
 
 # Start listening for events from sdp-driver
 # socat will fork sdp-dnsmasq-set-dns and it will send data receive in the socket to the

--- a/assets/sdp-dnsmasq-set-dns
+++ b/assets/sdp-dnsmasq-set-dns
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+# flock on the script itself, this way we ensure that we "queue" the executions
+# when sdp-driver calls the script.
 [ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -x "$0" "$0" "$@" || :
 
 # This script is executed by socat.

--- a/assets/sdp-dnsmasq-set-dns
+++ b/assets/sdp-dnsmasq-set-dns
@@ -4,10 +4,13 @@
 # It will get events from sdp-driver about DNS changes and it will
 # configure dnsmasq to use the new settings requested by sdp-driver
 
+function decho () {
+    echo $(date +"%b %d %X") $@
+}
+
 # NOTE: stdin reads from the socat socket.
 DNSMASQ_APPGATE=/etc/dnsmasq.d/appgate.conf
 USE_SERVER_ENTRIES=0
-SDP_LOGS_PIPE=/sdp-logs-pipe
 
 # This reuses later the first entry in the file since that entry
 # points to the kube_dns service
@@ -68,7 +71,7 @@ END {
 }
 
 read cli
-echo "Got new DNS configuration from sdp-driver: $cli" > $SDP_LOGS_PIPE
+decho "Got new DNS configuration from sdp-driver: $cli"
 opt=${cli%% *}
 reset=0
 while [ ! -z $opt ]; do
@@ -97,27 +100,32 @@ done
 
 if [[ -z "$servers" && -z $domains ]]; then
     if [[ $reset == 0 ]]; then
-        echo "--servers not provided, doing nothing" > $SDP_LOGS_PIPE
+        decho "--servers not provided, doing nothing"
         exit 0
     fi
 fi
 
-echo "Setting new DNS configuration" > $SDP_LOGS_PIPE
+decho "Setting new DNS configuration"
 echo $KUBE_DNS > $DNSMASQ_APPGATE
 for i in $(match_domains "$servers" "$domains"); do
    echo $i >> $DNSMASQ_APPGATE
 done
 
-echo "Applying new DNS configuration" > $SDP_LOGS_PIPE
+decho "Applying new DNS configuration"
 # dnsmasq can not reload files on SIHGUP so we need to restart it
 pid=$(pgrep dnsmasq)
 if [[ ! -z $pid ]]; then
     kill -9 $pid
 fi
-/sdp-dnsmasq/sdp-logger $SDP_LOGS_PIPE &
 res=1
 while [[ $res != 0 ]]; do
+    decho "Restarting dnsmasq ..."
     /usr/sbin/dnsmasq --pid-file=/sdp-dnsmasq/dnsmasq.pid --port=53 --local-service \
-		      --listen-address=127.0.0.1 --log-queries -8 $SDP_LOGS_PIPE
+              --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
     res=$?
+    if [[ $res != 0 ]]; then
+        # Wait a bit so we dont try like crazy to restart it
+        decho "Trying to restart dnsmasq again ...."
+        sleep 5
+    fi
 done

--- a/assets/sdp-dnsmasq-set-dns
+++ b/assets/sdp-dnsmasq-set-dns
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -x "$0" "$0" "$@" || :
+
 # This script is executed by socat.
 # It will get events from sdp-driver about DNS changes and it will
 # configure dnsmasq to use the new settings requested by sdp-driver

--- a/assets/sdp-dnsmasq-set-dns
+++ b/assets/sdp-dnsmasq-set-dns
@@ -123,7 +123,7 @@ res=1
 while [[ $res != 0 ]]; do
     decho "Restarting dnsmasq ..."
     /usr/sbin/dnsmasq --pid-file=/sdp-dnsmasq/dnsmasq.pid --port=53 --local-service \
-              --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
+                      --listen-address=127.0.0.1 --log-queries -8 /proc/1/fd/1
     res=$?
     if [[ $res != 0 ]]; then
         # Wait a bit so we dont try like crazy to restart it

--- a/assets/sdp-logger
+++ b/assets/sdp-logger
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-while read l ; do
-    echo "$(date): ${l}" > /proc/1/fd/1
-done < $1

--- a/docker/sdp-dnsmasq-Dockerfile
+++ b/docker/sdp-dnsmasq-Dockerfile
@@ -9,7 +9,5 @@ RUN apk upgrade --no-cache && \
 WORKDIR /sdp-dnsmasq
 COPY assets/sdp-dnsmasq /sdp-dnsmasq/sdp-dnsmasq
 COPY assets/sdp-dnsmasq-set-dns /sdp-dnsmasq/sdp-dnsmasq-set-dns
-COPY assets/sdp-logger /sdp-dnsmasq/sdp-logger
 RUN chmod +x /sdp-dnsmasq/sdp-dnsmasq
-RUN chmod +x /sdp-dnsmasq/sdp-logger
 CMD ["/sdp-dnsmasq/sdp-dnsmasq"]

--- a/docker/sdp-dnsmasq-Dockerfile
+++ b/docker/sdp-dnsmasq-Dockerfile
@@ -4,7 +4,7 @@ LABEL project=sdp-injector
 RUN apk upgrade --no-cache && \
     apk add --no-cache --virtual=run-deps dnsmasq socat && \
     rm -rf /tmp/* \
-           /var/cache/apk/*  \
+           /var/cache/apk/* \
            /var/tmp/*
 WORKDIR /sdp-dnsmasq
 COPY assets/sdp-dnsmasq /sdp-dnsmasq/sdp-dnsmasq


### PR DESCRIPTION
The named pipe was causing problems when restarting dnsmasq, dnsmasq was hanging because the pipe was broken. Avoid using it.