### PR TITLE
[SA-18120] Publish headless driver and service using public debian package

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  CLIENT_VERSION: 5.5.1
+
 jobs:
   sdp-injector:
     runs-on: ubuntu-latest
@@ -34,7 +37,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-injector:latest
-            ghcr.io/${{ github.repository }}/sdp-injector:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/sdp-injector:${{ env.CLIENT_VERSION }}
 
   sdp-dnsmasq:
     runs-on: ubuntu-latest
@@ -54,7 +57,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-dnsmasq:latest
-            ghcr.io/${{ github.repository }}/sdp-dnsmasq:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/sdp-dnsmasq:${{ env.CLIENT_VERSION }}
 
   sdp-headless-driver:
     runs-on: ubuntu-latest
@@ -74,7 +77,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-headless-driver:latest
-            ghcr.io/${{ github.repository }}/sdp-headless-driver:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/sdp-headless-driver:${{ env.CLIENT_VERSION }}
 
   sdp-headless-service:
     runs-on: ubuntu-latest
@@ -94,7 +97,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/${{ github.repository }}/sdp-headless-service:latest
-            ghcr.io/${{ github.repository }}/sdp-headless-service:${{ github.sha }}
+            ghcr.io/${{ github.repository }}/sdp-headless-service:${{ env.CLIENT_VERSION }}
 
   helm:
     runs-on: ubuntu-latest
@@ -112,6 +115,6 @@ jobs:
       - name: Lint chart
         run: helm lint k8s/chart
       - name: Package chart
-        run: helm package k8s/chart --app-version ${{ github.sha }}
+        run: helm package k8s/chart
       - name: Push chart
         run: helm push sdp-k8s-client-${{ env.chart_version }}.tgz oci://ghcr.io/appgate/charts/sdp-k8s-client

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,46 @@ jobs:
             ghcr.io/${{ github.repository }}/sdp-dnsmasq:latest
             ghcr.io/${{ github.repository }}/sdp-dnsmasq:${{ github.sha }}
 
+  sdp-headless-driver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/sdp-headless-driver-Dockerfile
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository }}/sdp-headless-driver:latest
+            ghcr.io/${{ github.repository }}/sdp-headless-driver:${{ github.sha }}
+
+  sdp-headless-service:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/sdp-headless-service-Dockerfile
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/${{ github.repository }}/sdp-headless-service:latest
+            ghcr.io/${{ github.repository }}/sdp-headless-service:${{ github.sha }}
+
   helm:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Package chart
         run: helm package k8s/chart --app-version ${{ github.sha }}
       - name: Push chart
-        run: helm push sdp-k8s-client-${{ env.chart_version }}.tgz oci://ghcr.io/${{ github.repository }}
+        run: helm push sdp-k8s-client-${{ env.chart_version }}.tgz oci://ghcr.io/appgate/charts/sdp-k8s-client

--- a/docker/sdp-client-headless-driver-Dockerfile
+++ b/docker/sdp-client-headless-driver-Dockerfile
@@ -1,14 +1,40 @@
+ARG MAJOR_VERSION=5
+ARG MINOR_VERSION=5
+ARG MAINTENANCE_VERSION=1
+ARG CLIENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
+ARG CLIENT_FULL_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${MAINTENANCE_VERSION}"
+ARG CLIENT_DEB="appgate-sdp-headless_${CLIENT_FULL_VERSION}_amd64.deb"
+
+FROM curlimages/curl:7.81.0 AS sdp-headless-client
+ARG CLIENT_VERSION
+ARG CLIENT_DEB
+ARG URL="https://bin.appgate-sdp.com/${CLIENT_VERSION}/client/${CLIENT_DEB}"
+RUN curl "${URL}" --output "/tmp/${CLIENT_DEB}"
+
 FROM ubuntu:18.04
 LABEL sdp=true
 LABEL project=sdp-client-headless
-ARG CLIENT_DEB=appgate-headless.deb
-COPY assets/$CLIENT_DEB /tmp
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt install -y /tmp/$CLIENT_DEB && \
-    apt-get clean
-RUN apt install -y iproute2 socat
-RUN rm -rf /usr/share/doc /usr/share/man /var/lib/apt /var/lib/dpkg /var/cache /etc/machine-id /tmp/$CLIENT_DEB
+ARG CLIENT_DEB
+
+COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
+RUN apt-get update && apt-get install -y \
+        "/tmp/$CLIENT_DEB" \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+        iproute2 \
+        socat \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /var/lib/apt \
+        /var/lib/dpkg \
+        /var/cache \
+        /etc/machine-id \
+        /tmp/$CLIENT_DEB
+
 COPY assets/sdp-driver-set-dns /opt/appgate/linux/set_dns
 RUN chmod +x /opt/appgate/linux/set_dns
 WORKDIR /root

--- a/docker/sdp-client-headless-service-Dockerfile
+++ b/docker/sdp-client-headless-service-Dockerfile
@@ -1,13 +1,37 @@
+ARG MAJOR_VERSION=5
+ARG MINOR_VERSION=5
+ARG MAINTENANCE_VERSION=1
+ARG CLIENT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}"
+ARG CLIENT_FULL_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${MAINTENANCE_VERSION}"
+ARG CLIENT_DEB="appgate-sdp-headless_${CLIENT_FULL_VERSION}_amd64.deb"
+
+FROM curlimages/curl:7.81.0 AS sdp-headless-client
+ARG CLIENT_VERSION
+ARG CLIENT_FULL_VERSION
+ARG CLIENT_DEB
+ARG URL="https://bin.appgate-sdp.com/${CLIENT_VERSION}/client/${CLIENT_DEB}"
+RUN curl "${URL}" --output "/tmp/${CLIENT_DEB}"
+
 FROM ubuntu:18.04
 LABEL sdp=true
 LABEL project=sdp-client-headless
-ARG CLIENT_DEB=appgate-headless.deb
-COPY assets/$CLIENT_DEB /tmp
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt install -y /tmp/$CLIENT_DEB && \
-    apt-get clean
-RUN rm -rf /usr/share/doc /usr/share/man /var/lib/apt /var/lib/dpkg /var/cache /etc/machine-id /tmp/$CLIENT_DEB
+ARG CLIENT_DEB
+
+COPY --from=sdp-headless-client "/tmp/${CLIENT_DEB}" "/tmp/${CLIENT_DEB}"
+
+RUN apt-get update && apt-get install -y \
+        "/tmp/$CLIENT_DEB" \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /var/lib/apt \
+        /var/lib/dpkg \
+        /var/cache \
+        /etc/machine-id \
+        /tmp/$CLIENT_DEB
+
 COPY assets/sdp-client-headless-service /opt/appgate/sdp-client-headless-service
 COPY assets/sdp-driver-pod-info /opt/appgate/pod_info
 RUN chmod +x /opt/appgate/sdp-client-headless-service

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: 5.5.1

--- a/k8s/chart/README.md
+++ b/k8s/chart/README.md
@@ -2,7 +2,7 @@
 
 ## Quickstart
 ```
-helm install sdp-k8s-client ghcr.io/appgate/sdp-k8s-client:latest
+helm install sdp-k8s-client ghcr.io/appgate/sdp-k8s-client:<version> 
 ```
 
 ## Parameters

--- a/k8s/chart/README.md
+++ b/k8s/chart/README.md
@@ -6,22 +6,28 @@ helm install sdp-k8s-client ghcr.io/appgate/sdp-k8s-client:<version>
 ```
 
 ## Parameters
-This table below was generated using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
+
 ### SDP parameters
 
-| Name                                   | Description                                                                             | Value                                      |
-| -------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `sdp.image.repository`                 | SDP injector, SDP Headless Driver, SDP Headless Service, and SDP Dnsmasq image registry | `ghcr.io/appgate/sdp-k8s-client`           |
-| `sdp.image.pullSecrets`                | SDP injector, SDP Headless Driver, SDP Headless Service, and SDP Dnsmasq pull secret    | `[]`                                       |
-| `sdp.injector.logLevel`                | SDP Injector log level                                                                  | `info`                                     |
-| `sdp.injector.image.tag`               | SDP Injector image tag                                                                  | `bf29001f31e85fe20b78ecb7ff34ecd4c67c4bbd` |
-| `sdp.injector.image.pullPolicy`        | SDP Injector pull policy                                                                | `IfNotPresent`                             |
-| `sdp.headlessService.image.tag`        | SDP Headless Service image tag                                                          | `latest`                                   |
-| `sdp.headlessService.image.pullPolicy` | SDP Headless Service image pull policy                                                  | `Always`                                   |
-| `sdp.headlessDriver.image.tag`         | SDP Headless Driver image tag                                                           | `latest`                                   |
-| `sdp.headlessDriver.image.pullPolicy`  | SDP Headless Driver image pull policy                                                   | `Always`                                   |
-| `sdp.dnsmasq.image.tag`                | SDP Dnsmasq image tag                                                                   | `bf29001f31e85fe20b78ecb7ff34ecd4c67c4bbd` |
-| `sdp.dnsmasq.image.pullPolicy`         | SDP Dnsmasq image pull policy                                                           | `IfNotPresent`                             |
+| Name                                   | Description                                                                              | Value                            |
+| -------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------- |
+| `global.image.repository`              | Image registry to use for all SDP images.                                                | `ghcr.io/appgate/sdp-k8s-client` |
+| `global.image.tag`                     | Image tag to use for all SDP images. If not set, it defaults to `.Chart.appVersion`.     | `""`                             |
+| `global.image.pullPolicy`              | Image pull policy to use for all SDP images.                                             | `IfNotPresent`                   |
+| `global.image.pullSecrets`             | Image pull secret to use for all SDP images.                                             | `[]`                             |
+| `sdp.injector.logLevel`                | SDP Injector log level.                                                                  | `info`                           |
+| `sdp.injector.image.repository`        | SDP Injector image repository. If set, it overrides `.global.image.repository`.          | `""`                             |
+| `sdp.injector.image.tag`               | SDP Injector image tag. If set, it overrides `.global.image.tag`.                        | `""`                             |
+| `sdp.injector.image.pullPolicy`        | SDP Injector pull policy. If set, it overrides `.global.image.pullPolicy`.               | `""`                             |
+| `sdp.headlessService.image.tag`        | SDP Headless Service image repository. If set, it overrides `.global.image.repository`.  | `""`                             |
+| `sdp.headlessService.image.repository` | SDP Headless Service image tag. If set, it overrides `.global.image.tag`.                | `""`                             |
+| `sdp.headlessService.image.pullPolicy` | SDP Headless Service image pull policy. If set, it overrides `.global.image.pullPolicy`. | `""`                             |
+| `sdp.headlessDriver.image.repository`  | SDP Headless Driver image repository. If set, it overrides `.global.image.repository`.   | `""`                             |
+| `sdp.headlessDriver.image.tag`         | SDP Headless Driver image tag. If set, it overrides `.global.image.tag`.                 | `""`                             |
+| `sdp.headlessDriver.image.pullPolicy`  | SDP Headless Service image pull policy. If set, it overrides `.global.image.pullPolicy`. | `""`                             |
+| `sdp.dnsmasq.image.repository`         | SDP Dnsmasq image repository. If set, it overrides `.global.image.repository`.           | `""`                             |
+| `sdp.dnsmasq.image.tag`                | SDP Dnsmasq image tag. If set, it overrides `.global.image.tag`.                         | `""`                             |
+| `sdp.dnsmasq.image.pullPolicy`         | SDP Dnsmasq image pull policy. If set, it overrides `.global.image.pullPolicy`.          | `""`                             |
 
 
 ### Kubernetes parameters
@@ -32,4 +38,6 @@ This table below was generated using [readme-generator-for-helm](https://github.
 | `rbac.create`           | Whether to create & use RBAC resources or not        | `true`      |
 | `service.type`          | Type of the service                                  | `ClusterIP` |
 | `service.port`          | Port of the service                                  | `443`       |
-| `replicaCount`          | Number of Kubewatch replicas to deploy               | `1`         |
+| `replicaCount`          | Number of SDP client replicas to deploy              | `1`         |
+
+This table above was generated using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)

--- a/k8s/chart/templates/_helpers.tpl
+++ b/k8s/chart/templates/_helpers.tpl
@@ -74,3 +74,10 @@ Sidecar Config
 {{- define "sdp-k8s-client.sidecar-config" -}}
 {{- printf "sdp-sidecar-config-%s" .Release.Name }}
 {{- end }}
+
+{{/*
+Default app version
+*/}}
+{{- define "sdp-k8s-client.defaultTag" -}}
+  {{- default .Chart.AppVersion .Values.global.image.tag }}
+{{- end -}}

--- a/k8s/chart/templates/configmap-sidecar.yaml
+++ b/k8s/chart/templates/configmap-sidecar.yaml
@@ -14,7 +14,7 @@ data:
       "containers": [
         {
           "name": "sdp-service",
-          "image": "{{ .Values.sdp.image.repository }}/sdp-headless-service:{{ .Values.sdp.headlessService.image.tag | default .Chart.AppVersion }}",
+          "image": "{{ default .Values.global.image.repository .Values.sdp.headlessService.image.repository }}/sdp-headless-service:{{ default (include "sdp-k8s-client.defaultTag" .) .Values.sdp.headlessService.image.tag}}",
           "imagePullPolicy": "{{.Values.sdp.headlessService.image.pullPolicy}}",
           "securityContext": {
             "runAsGroup": 0,
@@ -37,7 +37,7 @@ data:
         },
         {
           "name": "sdp-driver",
-          "image": "{{ .Values.sdp.image.repository }}/sdp-headless-driver:{{ .Values.sdp.headlessDriver.image.tag | default .Chart.AppVersion }}",
+          "image": "{{ default .Values.global.image.repository .Values.sdp.headlessDriver.image.repository }}/sdp-headless-driver:{{ default (include "sdp-k8s-client.defaultTag" .) .Values.sdp.headlessDriver.image.tag}}",
           "securityContext": {
             "runAsGroup": 0,
             "runAsNonRoot": false,
@@ -61,7 +61,7 @@ data:
         },
         {
           "name": "sdp-dnsmasq",
-          "image": "{{ .Values.sdp.image.repository }}/sdp-dnsmasq:{{ .Values.sdp.dnsmasq.image.tag | default .Chart.AppVersion }}",
+          "image": "{{ default .Values.global.image.repository .Values.sdp.dnsmasq.image.repository }}/sdp-dnsmasq:{{ default (include "sdp-k8s-client.defaultTag" .) .Values.sdp.dnsmasq.image.tag}}",
           "imagePullPolicy": "{{.Values.sdp.dnsmasq.image.pullPolicy}}",
           "securityContext": {
             "runAsGroup": 0,

--- a/k8s/chart/templates/deployment.yaml
+++ b/k8s/chart/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               value: {{ .Values.sdp.injector.logLevel | default "info" }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.sdp.image.repository }}/sdp-injector:{{ .Values.sdp.headlessDriver.image.tag | default .Chart.AppVersion }}"
+          image: "{{ default .Values.global.image.repository .Values.sdp.injector.image.repository }}/sdp-injector:{{ default (include "sdp-k8s-client.defaultTag" .) .Values.sdp.headlessDriver.image.tag }}"
           imagePullPolicy: {{ .Values.sdp.injector.image.pullPolicy }}
           volumeMounts:
             - name: sdp-injector-secrets-and-config

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -3,11 +3,16 @@
 ## SDP
 ## ref: https://github.com/appgate/sdp-k8s-client
 ##
-sdp:
-  ## @param sdp.image.repository SDP injector, SDP Headless Driver, SDP Headless Service, and SDP Dnsmasq image registry
-  ## @param sdp.image.pullSecrets SDP injector, SDP Headless Driver, SDP Headless Service, and SDP Dnsmasq pull secret
+
+global:
+  ## @param global.image.repository Image registry to use for all SDP images.
+  ## @param global.image.tag Image tag to use for all SDP images. If not set, it defaults to `.Chart.appVersion`.
+  ## @param global.image.pullPolicy Image pull policy to use for all SDP images.
+  ## @param global.image.pullSecrets Image pull secret to use for all SDP images.
   image:
     repository: ghcr.io/appgate/sdp-k8s-client
+    tag: ""
+    pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -16,39 +21,48 @@ sdp:
     ##   - myRegistryKeySecretName
     pullSecrets: []
 
-  ## @param sdp.injector.logLevel SDP Injector log level
-  ## @param sdp.injector.image.tag SDP Injector image tag
-  ## @param sdp.injector.image.pullPolicy SDP Injector pull policy
+sdp:
+  ## @param sdp.injector.logLevel SDP Injector log level.
+  ## @param sdp.injector.image.repository SDP Injector image repository. If set, it overrides `.global.image.repository`.
+  ## @param sdp.injector.image.tag SDP Injector image tag. If set, it overrides `.global.image.tag`.
+  ## @param sdp.injector.image.pullPolicy SDP Injector pull policy. If set, it overrides `.global.image.pullPolicy`.
   injector:
     logLevel: info
     image:
-      tag: latest
+      repository: ""
+      tag: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
       ##
-      pullPolicy: IfNotPresent
+      pullPolicy: ""
 
-  ## @param sdp.headlessService.image.tag SDP Headless Service image tag
-  ## @param sdp.headlessService.image.pullPolicy SDP Headless Service image pull policy
+  ## @param sdp.headlessService.image.tag SDP Headless Service image repository. If set, it overrides `.global.image.repository`.
+  ## @param sdp.headlessService.image.repository SDP Headless Service image tag. If set, it overrides `.global.image.tag`.
+  ## @param sdp.headlessService.image.pullPolicy SDP Headless Service image pull policy. If set, it overrides `.global.image.pullPolicy`.
   headlessService:
     image:
-      tag: latest
-      pullPolicy: IfNotPresent
+      repository: ""
+      tag: ""
+      pullPolicy: ""
 
-  ## @param sdp.headlessDriver.image.tag SDP Headless Driver image tag
-  ## @param sdp.headlessDriver.image.pullPolicy SDP Headless Driver image pull policy
+  ## @param sdp.headlessDriver.image.repository SDP Headless Driver image repository. If set, it overrides `.global.image.repository`.
+  ## @param sdp.headlessDriver.image.tag SDP Headless Driver image tag. If set, it overrides `.global.image.tag`.
+  ## @param sdp.headlessDriver.image.pullPolicy SDP Headless Service image pull policy. If set, it overrides `.global.image.pullPolicy`.
   headlessDriver:
     image:
-      tag: latest
-      pullPolicy: IfNotPresent
+      repository: ""
+      tag: ""
+      pullPolicy: ""
 
-  ## @param sdp.dnsmasq.image.tag SDP Dnsmasq image tag
-  ## @param sdp.dnsmasq.image.pullPolicy SDP Dnsmasq image pull policy
+  ## @param sdp.dnsmasq.image.repository SDP Dnsmasq image repository. If set, it overrides `.global.image.repository`.
+  ## @param sdp.dnsmasq.image.tag SDP Dnsmasq image tag. If set, it overrides `.global.image.tag`.
+  ## @param sdp.dnsmasq.image.pullPolicy SDP Dnsmasq image pull policy. If set, it overrides `.global.image.pullPolicy`.
   dnsmasq:
     image:
-      tag: latest
-      pullPolicy: IfNotPresent
+      repository: ""
+      tag: ""
+      pullPolicy: ""
 
 ## @section Kubernetes parameters
 

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -22,7 +22,7 @@ sdp:
   injector:
     logLevel: info
     image:
-      tag: bf29001f31e85fe20b78ecb7ff34ecd4c67c4bbd
+      tag: latest
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -34,20 +34,20 @@ sdp:
   headlessService:
     image:
       tag: latest
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
 
   ## @param sdp.headlessDriver.image.tag SDP Headless Driver image tag
   ## @param sdp.headlessDriver.image.pullPolicy SDP Headless Driver image pull policy
   headlessDriver:
     image:
       tag: latest
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
 
   ## @param sdp.dnsmasq.image.tag SDP Dnsmasq image tag
   ## @param sdp.dnsmasq.image.pullPolicy SDP Dnsmasq image pull policy
   dnsmasq:
     image:
-      tag: bf29001f31e85fe20b78ecb7ff34ecd4c67c4bbd
+      tag: latest
       pullPolicy: IfNotPresent
 
 ## @section Kubernetes parameters


### PR DESCRIPTION
* Updated dockerfile for headless driver and service to pull debian package from public repo
* Added github action to publish the images
* Set versioning. I set the `.Chart.appVersion` as `5.5.1` as that is the version used in the docker images.
* Added flexibility in chart to be able to override the individual component's image repository and tag. This will be useful when we want to mix-and-match the different versions of the images. 