### PR TITLE
Remove extra 'sdp-k8s-client'

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,4 +121,4 @@ jobs:
         run: helm package k8s/chart
       - name: Push chart
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: helm push sdp-k8s-client-${{ env.chart_version }}.tgz oci://ghcr.io/appgate/charts/sdp-k8s-client
+        run: helm push sdp-k8s-client-${{ env.chart_version }}.tgz oci://ghcr.io/appgate/charts


### PR DESCRIPTION
Just a quick one if we'd prefer it. We can keep the `ghcr.io/appgate/sdp-k8s-client/sdp-k8s-client` for a while until no one uses it anymore. Shouldn't be long though, since the chart README actually references this path already.