### PR TITLE
Create secret and cleanup old secret and admission webhook in initContainer

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/chart/templates/job-preinstall.yaml
+++ b/k8s/chart/templates/job-preinstall.yaml
@@ -35,6 +35,14 @@ spec:
       securityContext:
         runAsUser: 1000
       initContainers:
+        - name: delete-secret
+          image: "bitnami/kubectl"
+          command: [ "kubectl" ]
+          args: [ "delete", "secret", "{{ include "sdp-k8s-client.injector-secret" . }}", "--namespace", "{{ include "sdp-k8s-client.namespace" . }}", "--ignore-not-found", "true" ]
+        - name: delete-admission-webhook
+          image: "bitnami/kubectl"
+          command: [ "kubectl" ]
+          args: [ "delete", "mutatingwebhookconfigurations", "sdp-admission-webhook-{{ .Release.Name }}", "--ignore-not-found", "true" ]
         - name: create-sdp-ca-key
           image: "alpine/openssl"
           volumeMounts:
@@ -93,23 +101,15 @@ spec:
               mountPath: /tmp
           command: ["openssl"]
           args: ["x509", "-text", "-in", "/tmp/sdp-injector-crt.pem"]
-      containers:
-        - name: delete-secret
-          image: "bitnami/kubectl"
-          command: ["kubectl"]
-          args: [ "delete", "secret", "{{ include "sdp-k8s-client.injector-secret" . }}", "--namespace", "{{ include "sdp-k8s-client.namespace" . }}", "--ignore-not-found", "true"]
         - name: create-secret
           image: "bitnami/kubectl"
-          command: ["kubectl"]
-          args: [ "create", "secret", "generic", "{{ include "sdp-k8s-client.injector-secret" . }}", "--from-file=sdp-ca.crt=/tmp/sdp-ca.crt", "--from-file=sdp-injector-key.pem=/tmp/sdp-injector-key.pem", "--from-file=sdp-injector-crt.pem=/tmp/sdp-injector-crt.pem", "--namespace", "{{ include "sdp-k8s-client.namespace" . }}"]
+          command: [ "kubectl" ]
+          args: [ "create", "secret", "generic", "{{ include "sdp-k8s-client.injector-secret" . }}", "--from-file=sdp-ca.crt=/tmp/sdp-ca.crt", "--from-file=sdp-injector-key.pem=/tmp/sdp-injector-key.pem", "--from-file=sdp-injector-crt.pem=/tmp/sdp-injector-crt.pem", "--namespace", "{{ include "sdp-k8s-client.namespace" . }}" ]
           volumeMounts:
             - name: tmp
               mountPath: /tmp
               readOnly: true
-        - name: delete-admission-webhook
-          image: "bitnami/kubectl"
-          command: ["kubectl"]
-          args: [ "delete", "mutatingwebhookconfigurations", "sdp-admission-webhook-{{ .Release.Name }}", "--ignore-not-found", "true"]
+      containers:
         - name: create-admission-webhook
           image: "alpine:3"
           securityContext:


### PR DESCRIPTION
Issue reported by customer where secret `sdp-client-secret-<RELEASE_NAME>` gets deleted immediately after creation because the execution order is not preserved inside `containers`. By moving the creation of secret and cleanup old resource into the `initContainers` section, we can guarantee execution order. 

Bumped up the chart version to `0.1.2`