### PR TITLE
Fix test when running in --release mode

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --release
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --release
 
   docker-rust:
     needs:

--- a/sdp-device-id-service/src/device_id_manager.rs
+++ b/sdp-device-id-service/src/device_id_manager.rs
@@ -6,7 +6,7 @@ use kube::{Api, Client, Resource};
 use sdp_common::crd::{DeviceId, DeviceIdSpec, ServiceIdentity};
 use sdp_common::kubernetes::SDP_K8S_NAMESPACE;
 use sdp_common::traits::{HasCredentials, Named, Namespaced, Service};
-use sdp_macros::{logger, queue_debug, sdp_error, sdp_info, sdp_log, with_dollar_sign};
+use sdp_macros::{logger, queue_info, sdp_error, sdp_info, sdp_log, with_dollar_sign};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
@@ -283,7 +283,7 @@ impl DeviceIdManagerRunner<ServiceIdentity, DeviceId> {
         queue_tx: Option<&Sender<DeviceIdManagerProtocol<F>>>,
     ) {
         info!("Starting Device ID Manager loop");
-        queue_debug!(DeviceIdManagerProtocol::<F>::DeviceIdManagerStarted => queue_tx);
+        queue_info!(DeviceIdManagerProtocol::<F>::DeviceIdManagerStarted => queue_tx);
 
         while let Some(message) = manager_proto_rx.recv().await {
             match message {
@@ -340,7 +340,9 @@ impl DeviceIdManagerRunner<ServiceIdentity, DeviceId> {
     ) -> () {
         info!("Starting Device ID Manager");
         DeviceIdManagerRunner::initialize(&mut self.dm).await;
-        queue_debug!(DeviceIdManagerProtocol::<ServiceIdentity>::DeviceIdManagerInitialized => queue_tx);
+        queue_info! {
+            DeviceIdManagerProtocol::<ServiceIdentity>::DeviceIdManagerInitialized => queue_tx
+        };
 
         watcher_proto_tx
             .send(ServiceIdentityWatcherProtocol::DeviceIdManagerReady)

--- a/sdp-identity-service/src/identity_manager.rs
+++ b/sdp-identity-service/src/identity_manager.rs
@@ -10,7 +10,7 @@ use sdp_common::traits::{
     HasCredentials, Labeled, MaybeNamespaced, MaybeService, Named, Namespaced, Service,
 };
 use sdp_macros::{
-    logger, queue_debug, sdp_error, sdp_info, sdp_log, sdp_warn, when_ok, with_dollar_sign,
+    logger, queue_info, sdp_error, sdp_info, sdp_log, sdp_warn, when_ok, with_dollar_sign,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
@@ -379,7 +379,7 @@ impl IdentityManagerRunner<ServiceLookup, ServiceIdentity> {
         let mut existing_activated_credentials: HashSet<String> = HashSet::new();
         let mut existing_deactivated_credentials: HashSet<String> = HashSet::new();
 
-        queue_debug! {
+        queue_info! {
             IdentityManagerProtocol::<F, ServiceIdentity>::IdentityManagerStarted => external_queue_tx
         };
 
@@ -769,7 +769,7 @@ impl IdentityManagerRunner<ServiceLookup, ServiceIdentity> {
         info!("Starting Identity Manager service");
         IdentityManagerRunner::initialize(&mut self.im).await;
 
-        queue_debug! {
+        queue_info! {
             IdentityManagerProtocol::<Deployment, ServiceIdentity>::IdentityManagerInitialized => external_queue_tx
         };
 

--- a/sdp-macros/src/lib.rs
+++ b/sdp-macros/src/lib.rs
@@ -1,11 +1,9 @@
 #[macro_export]
-macro_rules! queue_debug {
+macro_rules! queue_info {
     ($msg:expr => $q:ident) => {
-        if cfg!(debug_assertions) {
-            if let Some(ref q) = $q {
-                if let Err(err) = q.send($msg).await {
-                    log::error!("Error notifying external watcher:{:?} => {}", $msg, err)
-                }
+        if let Some(ref q) = $q {
+            if let Err(err) = q.send($msg).await {
+                log::error!("Error notifying external watcher:{:?} => {}", $msg, err)
             }
         }
     };
@@ -127,17 +125,13 @@ macro_rules! with_dollar_sign {
 macro_rules! sdp_log {
     ($logger:ident | $protocol:path | $module:literal | ($target:expr $(, $arg:expr)*) => $q:ident) => {
         let t = format!($target $(, $arg)*);
-        if cfg!(debug_assertions) {
-            queue_debug!($protocol(t.to_string()) => $q);
-        }
+        queue_info!($protocol(t.to_string()) => $q);
         log::$logger!("[{}] {}", $module, t);
     };
 
     ($logger:ident | $protocol:path | ($target:expr $(, $arg:expr)*) => $q:ident) => {
-        if cfg!(debug_assertions) {
-            let t = format!($target $(, $arg)*);
-            queue_debug!($protocol(t.to_string()) => $q);
-        }
+        let t = format!($target $(, $arg)*);
+        queue_info!($protocol(t.to_string()) => $q);
         log::$logger!($target $(, $arg)*);
     };
 


### PR DESCRIPTION
When we run `cargo test` in main branch, it runs in --release mode. When release mode is enabled, debug logs are disabled. Because we had tests that were checking debug log messages, the tests only failed when merged with main. Fix the test so the messages are logged even in --release mode.

Also always run tests in --release